### PR TITLE
Replaced local 'util' dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,10 +42,12 @@ application {
 repositories {
 	jcenter()
 	maven(url = "http://maven.bluexin.be/repository/snapshots/")
+	maven(url = "https://jitpack.io")
 }
 
 dependencies {
-	compile("xerus.util", "javafx")
+	// TODO
+	compile("com.github.fwcd", "util", "master-SNAPSHOT") // Always builds the current version
 	compile(kotlin("stdlib-jdk8"))
 	
 	compile("org.controlsfx", "controlsfx", "8.40.+")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,8 +46,7 @@ repositories {
 }
 
 dependencies {
-	// TODO
-	compile("com.github.fwcd", "util", "master-SNAPSHOT") // Always builds the current version
+	compile("com.github.Xerus2000", "util", "master-SNAPSHOT") // Always builds the current version
 	compile(kotlin("stdlib-jdk8"))
 	
 	compile("org.controlsfx", "controlsfx", "8.40.+")

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,1 @@
 rootProject.name = 'MonsterUtilities'
-
-includeBuild '../util'

--- a/src/main/xerus/monstercat/tabs/TabSound.kt
+++ b/src/main/xerus/monstercat/tabs/TabSound.kt
@@ -56,7 +56,7 @@ class TabSound : VTab() {
 						band.gainProperty().bind(valueProperty())
 						valueProperty().set(value)
 						valueProperty().listen { listener(it as Double) }
-					}.scrollable(),
+					}.scrollable(1.0),
 					Label(band.centerFrequency.toString())
 			)
 		}

--- a/src/main/xerus/monstercat/tabs/TabSound.kt
+++ b/src/main/xerus/monstercat/tabs/TabSound.kt
@@ -56,7 +56,7 @@ class TabSound : VTab() {
 						band.gainProperty().bind(valueProperty())
 						valueProperty().set(value)
 						valueProperty().listen { listener(it as Double) }
-					}.scrollable(1.0),
+					}.scrollable(),
 					Label(band.centerFrequency.toString())
 			)
 		}


### PR DESCRIPTION
**This PR requires [PR nr. 2 in 'util' to be fully merged](https://github.com/Xerus2000/util/pull/2).**

It fixes issue #18 and removes the dependency on the local 'util' project. This project now independently fetches and automatically builds the newest version of 'util' from GitHub (Build versions are cached in the Jitpack repository).