### PR TITLE
Additional setting for maximum APIConnection simultaneous connections

### DIFF
--- a/src/main/xerus/monstercat/Settings.kt
+++ b/src/main/xerus/monstercat/Settings.kt
@@ -18,32 +18,35 @@ import java.io.File
 object Settings : SettingsNode("xerus/monsterutilities") {
 	private val logger = KotlinLogging.logger { }
 	
+	// Player settings
 	val PLAYERVOLUME = create("playerVolume", 0.4)
 	val PLAYERSCROLLSENSITIVITY = create("playerSeekbarScrollSensitivity", 6.0)
 	val PLAYERSEEKBARHEIGHT = create("playerSeekbarHeight", 8.0)
 	val ENABLEEQUALIZER = create("equalizerEnabled", false)
 	
-	val ENABLECACHE = create("cacheEnabled", true)
-	
+	// Theme and base app settings
+	val THEME = create("theme", Themes.BLACK)
 	val STARTUPTAB = create("tabStartup", "Previous")
 	val LASTTAB = create("tabLast")
 	
+	// Catalog tab settings
 	val LASTCATALOGCOLUMNS = create("catalogLastColumns", availableColumns)
 	val VISIBLECATALOGCOLUMNS = create("catalogVisibleColumns", defaultColumns)
 	val GENRECOLORINTENSITY = create("genrecolors", 80)
 	
-	val THEME = create("theme", Themes.BLACK)
-	
+	// Update mechanism
 	val LASTVERSION = create("versionLast")
 	val IGNOREVERSION = create("versionIgnore")
 	val DELETE = create("versionDelete", File(""))
-	
 	val AUTOUPDATE = create("updateAutomatic", true)
 	val UNSTABLE = create("updateUnstable", false)
 	
+	// Downloader settings
 	val FILENAMEPATTERN = create("updatePattern", "MonsterUtilities-%version%.jar")
-
+	
+	// Connection and API settings
 	val CONNECTIONSPEED = create("connectionSpeed", ConnectionSpeed.ADSL)
+	val ENABLECACHE = create("cacheEnabled", true)
 	
 	init {
 		ENABLECACHE.listen { selected ->

--- a/src/main/xerus/monstercat/Settings.kt
+++ b/src/main/xerus/monstercat/Settings.kt
@@ -5,6 +5,7 @@ import javafx.beans.value.ObservableValue
 import javafx.scene.control.Alert
 import javafx.scene.control.ButtonBar
 import mu.KotlinLogging
+import xerus.ktutil.helpers.Named
 import xerus.ktutil.javafx.applyTheme
 import xerus.ktutil.javafx.Themes
 import xerus.ktutil.javafx.properties.listen
@@ -42,11 +43,14 @@ object Settings : SettingsNode("xerus/monsterutilities") {
 	
 	val FILENAMEPATTERN = create("updatePattern", "MonsterUtilities-%version%.jar")
 	
-	enum class ConnectionSpeed(val maxConnections: Int, val display: String) {
+	enum class ConnectionSpeed(val maxConnections: Int, val display: String) : Named {
 		DIALUP(5, "Dial-up (100 kb/s)"),
 		ADSL(30, "ADSL / 3G (10 Mb/s)"),
 		CABLE(150, "Cable / 4G (100 Mb/s)"),
 		FIBER(300, "Fiber (300+ Mb/s)");
+
+		override val displayName: String
+			get() = display
 
 		override fun toString(): String = display
 		
@@ -70,7 +74,7 @@ object Settings : SettingsNode("xerus/monsterutilities") {
 			}
 		}
 	}
-	val CONNECTIONSPEED = create("connectionSpeed", ConnectionSpeed.ADSL.maxConnections)
+	val CONNECTIONSPEED = create("connectionSpeed", ConnectionSpeed.ADSL)
 	
 	init {
 		ENABLECACHE.listen { selected ->

--- a/src/main/xerus/monstercat/Settings.kt
+++ b/src/main/xerus/monstercat/Settings.kt
@@ -55,23 +55,10 @@ object Settings : SettingsNode("xerus/monsterutilities") {
 		override fun toString(): String = display
 		
 		companion object {
-			fun findFromValue(maxConnections: Int): ConnectionSpeed {
-				ConnectionSpeed.values().forEach {
-					if (it.maxConnections == maxConnections)
-						return it
-				}
-				logger.warn("ConnectionSpeed Enum couldn't be found from value $maxConnections")
-				return ADSL // Default value
-			}
+			fun findFromValue(maxConnections: Int) =
+					ConnectionSpeed.values().find { it.maxConnections == maxConnections } ?: ADSL
 			
-			fun findFromString(string: String): ConnectionSpeed {
-				ConnectionSpeed.values().forEach {
-					if (it.toString() == string)
-						return it
-				}
-				logger.warn("ConnectionSpeed Enum couldn't be found from value $string")
-				return ADSL // Default value
-			}
+			fun findFromString(string: String) = ConnectionSpeed.values().find { it.toString() == string } ?: ADSL
 		}
 	}
 	val CONNECTIONSPEED = create("connectionSpeed", ConnectionSpeed.ADSL)

--- a/src/main/xerus/monstercat/Settings.kt
+++ b/src/main/xerus/monstercat/Settings.kt
@@ -42,19 +42,13 @@ object Settings : SettingsNode("xerus/monsterutilities") {
 	
 	val FILENAMEPATTERN = create("updatePattern", "MonsterUtilities-%version%.jar")
 	
-	enum class ConnectionSpeed(val maxConnections: Int) {
-		DIALUP(5) {
-			override fun toString() = "Dial-up (100 kb/s)"
-		},
-		ADSL(30) {
-			override fun toString() = "ADSL / 3G (10 Mb/s)"
-		},
-		CABLE(150) {
-			override fun toString() = "Cable / 4G (100 Mb/s)"
-		},
-		FIBER(300) {
-			override fun toString() = "Fiber (300+ Mb/s)"
-		};
+	enum class ConnectionSpeed(val maxConnections: Int, val display: String) {
+		DIALUP(5, "Dial-up (100 kb/s)"),
+		ADSL(30, "ADSL / 3G (10 Mb/s)"),
+		CABLE(150, "Cable / 4G (100 Mb/s)"),
+		FIBER(300, "Fiber (300+ Mb/s)");
+
+		override fun toString(): String = display
 		
 		companion object {
 			fun findFromValue(maxConnections: Int): ConnectionSpeed {

--- a/src/main/xerus/monstercat/Settings.kt
+++ b/src/main/xerus/monstercat/Settings.kt
@@ -74,6 +74,8 @@ object Settings : SettingsNode("xerus/monsterutilities") {
 			}
 		}
 	}
+	val CONNECTIONSPEED = create("connectionSpeed", ConnectionSpeed.ADSL.maxConnections)
+	
 	init {
 		ENABLECACHE.listen { selected ->
 			logger.debug("Cache " + (if (selected) "en" else "dis") + "abled")

--- a/src/main/xerus/monstercat/Settings.kt
+++ b/src/main/xerus/monstercat/Settings.kt
@@ -42,6 +42,38 @@ object Settings : SettingsNode("xerus/monsterutilities") {
 	
 	val FILENAMEPATTERN = create("updatePattern", "MonsterUtilities-%version%.jar")
 	
+	enum class ConnectionSpeed(val maxConnections: Int) {
+		DIALUP(5) {
+			override fun toString() = "Dial-up (100 kb/s)"
+		},
+		ADSL(30) {
+			override fun toString() = "ADSL / 3G (1 Mb/s)"
+		},
+		CABLE(150) {
+			override fun toString() = "Cable / 4G (100 Mb/s)"
+		},
+		FIBER(300) {
+			override fun toString() = "Fiber (300+ Mb/s)"
+		};
+		
+		companion object {
+			fun findFromValue(maxConnections: Int): ConnectionSpeed {
+				ConnectionSpeed.values().forEach {
+					if (it.maxConnections == maxConnections)
+						return it
+				}
+				return ADSL // Default value
+			}
+			
+			fun findFromString(string: String): ConnectionSpeed {
+				ConnectionSpeed.values().forEach {
+					if (it.toString() == string)
+						return it
+				}
+				return ADSL // Default value
+			}
+		}
+	}
 	init {
 		ENABLECACHE.listen { selected ->
 			logger.debug("Cache " + (if (selected) "en" else "dis") + "abled")

--- a/src/main/xerus/monstercat/Settings.kt
+++ b/src/main/xerus/monstercat/Settings.kt
@@ -47,7 +47,7 @@ object Settings : SettingsNode("xerus/monsterutilities") {
 			override fun toString() = "Dial-up (100 kb/s)"
 		},
 		ADSL(30) {
-			override fun toString() = "ADSL / 3G (1 Mb/s)"
+			override fun toString() = "ADSL / 3G (10 Mb/s)"
 		},
 		CABLE(150) {
 			override fun toString() = "Cable / 4G (100 Mb/s)"

--- a/src/main/xerus/monstercat/Settings.kt
+++ b/src/main/xerus/monstercat/Settings.kt
@@ -42,25 +42,7 @@ object Settings : SettingsNode("xerus/monsterutilities") {
 	val UNSTABLE = create("updateUnstable", false)
 	
 	val FILENAMEPATTERN = create("updatePattern", "MonsterUtilities-%version%.jar")
-	
-	enum class ConnectionSpeed(val maxConnections: Int, val display: String) : Named {
-		DIALUP(5, "Dial-up (100 kb/s)"),
-		ADSL(30, "ADSL / 3G (10 Mb/s)"),
-		CABLE(150, "Cable / 4G (100 Mb/s)"),
-		FIBER(300, "Fiber (300+ Mb/s)");
 
-		override val displayName: String
-			get() = display
-
-		override fun toString(): String = display
-		
-		companion object {
-			fun findFromValue(maxConnections: Int) =
-					ConnectionSpeed.values().find { it.maxConnections == maxConnections } ?: ADSL
-			
-			fun findFromString(string: String) = ConnectionSpeed.values().find { it.toString() == string } ?: ADSL
-		}
-	}
 	val CONNECTIONSPEED = create("connectionSpeed", ConnectionSpeed.ADSL)
 	
 	init {
@@ -91,5 +73,21 @@ object Settings : SettingsNode("xerus/monsterutilities") {
 		
 		THEME.listen { monsterUtilities.scene.applyTheme(it) }
 	}
-	
+
+	// ENUMs
+	enum class ConnectionSpeed(val maxConnections: Int, override val displayName: String) : Named {
+		DIALUP(5, "Dial-up (100 kb/s)"),
+		ADSL(30, "ADSL / 3G (10 Mb/s)"),
+		CABLE(150, "Cable / 4G (100 Mb/s)"),
+		FIBER(300, "Fiber (300+ Mb/s)");
+
+		override fun toString(): String = displayName
+
+		companion object {
+			fun findFromValue(maxConnections: Int) =
+					ConnectionSpeed.values().find { it.maxConnections == maxConnections } ?: ADSL
+
+			fun findFromString(string: String) = ConnectionSpeed.values().find { it.toString() == string } ?: ADSL
+		}
+	}
 }

--- a/src/main/xerus/monstercat/Settings.kt
+++ b/src/main/xerus/monstercat/Settings.kt
@@ -62,6 +62,7 @@ object Settings : SettingsNode("xerus/monsterutilities") {
 					if (it.maxConnections == maxConnections)
 						return it
 				}
+				logger.warn("ConnectionSpeed Enum couldn't be found from value $maxConnections")
 				return ADSL // Default value
 			}
 			
@@ -70,6 +71,7 @@ object Settings : SettingsNode("xerus/monsterutilities") {
 					if (it.toString() == string)
 						return it
 				}
+				logger.warn("ConnectionSpeed Enum couldn't be found from value $string")
 				return ADSL // Default value
 			}
 		}

--- a/src/main/xerus/monstercat/api/APIConnection.kt
+++ b/src/main/xerus/monstercat/api/APIConnection.kt
@@ -108,7 +108,8 @@ class APIConnection(vararg path: String) : HTTPQuery<APIConnection>() {
 	override fun toString(): String = "APIConnection(uri=$uri)"
 	
 	companion object {
-		var maxConnections = min(Settings.CONNECTIONSPEED.get(), Runtime.getRuntime().availableProcessors().coerceAtLeast(2) * 50)
+		private fun getRealMaxConnections(networkMax: Int) = min(networkMax, Runtime.getRuntime().availableProcessors().coerceAtLeast(2) * 50)
+		var maxConnections = getRealMaxConnections(Settings.CONNECTIONSPEED.get())
 		private var httpClient = createHttpClient(CONNECTSID())
 		
 		val connectValidity = SimpleObservable(ConnectValidity.NOCONNECTION, true)
@@ -157,7 +158,7 @@ class APIConnection(vararg path: String) : HTTPQuery<APIConnection>() {
 				logger.debug("Initial maxConnections set is ${maxConnections}")
 				Settings.CONNECTIONSPEED.listen { newValue ->
 					logger.debug("Changed maxConnections to ${maxConnections}")
-					maxConnections = min(Settings.CONNECTIONSPEED.get(), Runtime.getRuntime().availableProcessors().coerceAtLeast(2) * 50)
+					maxConnections = getRealMaxConnections(newValue)
 					defaultMaxPerRoute = (maxConnections * 0.9).toInt()
 					maxTotal = maxConnections
 				}

--- a/src/main/xerus/monstercat/api/APIConnection.kt
+++ b/src/main/xerus/monstercat/api/APIConnection.kt
@@ -153,7 +153,9 @@ class APIConnection(vararg path: String) : HTTPQuery<APIConnection>() {
 			connectionManager = PoolingHttpClientConnectionManager().apply {
 				defaultMaxPerRoute = (maxConnections.get() * 0.9).toInt()
 				maxTotal = maxConnections.get()
+				logger.debug("Initial maxConnections set is ${maxConnections.get()}")
 				maxConnections.addListener { _, _, newValue ->
+					logger.debug("Changed maxConnections to ${maxConnections.get()}")
 					defaultMaxPerRoute = newValue
 					maxTotal = newValue
 				}

--- a/src/main/xerus/monstercat/api/APIConnection.kt
+++ b/src/main/xerus/monstercat/api/APIConnection.kt
@@ -109,7 +109,7 @@ class APIConnection(vararg path: String) : HTTPQuery<APIConnection>() {
 	
 	companion object {
 		private fun getRealMaxConnections(networkMax: Int) = min(networkMax, Runtime.getRuntime().availableProcessors().coerceAtLeast(2) * 50)
-		var maxConnections = getRealMaxConnections(Settings.CONNECTIONSPEED.get())
+		var maxConnections = getRealMaxConnections(Settings.CONNECTIONSPEED.get().maxConnections)
 		private var httpClient = createHttpClient(CONNECTSID())
 		
 		val connectValidity = SimpleObservable(ConnectValidity.NOCONNECTION, true)
@@ -157,8 +157,8 @@ class APIConnection(vararg path: String) : HTTPQuery<APIConnection>() {
 				maxTotal = maxConnections
 				logger.debug("Initial maxConnections set is ${maxConnections}")
 				Settings.CONNECTIONSPEED.listen { newValue ->
+					maxConnections = getRealMaxConnections(newValue.maxConnections)
 					logger.debug("Changed maxConnections to ${maxConnections}")
-					maxConnections = getRealMaxConnections(newValue)
 					defaultMaxPerRoute = (maxConnections * 0.9).toInt()
 					maxTotal = maxConnections
 				}

--- a/src/main/xerus/monstercat/api/APIConnection.kt
+++ b/src/main/xerus/monstercat/api/APIConnection.kt
@@ -154,7 +154,7 @@ class APIConnection(vararg path: String) : HTTPQuery<APIConnection>() {
 				defaultMaxPerRoute = (maxConnections.get() * 0.9).toInt()
 				maxTotal = maxConnections.get()
 				logger.debug("Initial maxConnections set is ${maxConnections.get()}")
-				maxConnections.addListener { _, _, newValue ->
+				maxConnections.listen { newValue ->
 					logger.debug("Changed maxConnections to ${maxConnections.get()}")
 					defaultMaxPerRoute = newValue
 					maxTotal = newValue

--- a/src/main/xerus/monstercat/tabs/TabSettings.kt
+++ b/src/main/xerus/monstercat/tabs/TabSettings.kt
@@ -79,19 +79,6 @@ class TabSettings: VTab() {
 		})
 
 		val connectionSpeed = createComboBox(Settings.CONNECTIONSPEED)
-		/*
-		val connectionSpeed = ComboBox<String>(FXCollections.observableArrayList())
-		onFx {
-			Settings.ConnectionSpeed.values().reversedArray().forEach {
-				connectionSpeed.items.add(it.toString())
-			}
-			connectionSpeed.valueProperty().bindBidirectional(Settings.CONNECTIONSPEED, {
-				Settings.ConnectionSpeed.findFromString(it).maxConnections
-			}, {
-				Settings.ConnectionSpeed.findFromValue(it).toString()
-			})
-			connectionSpeed.select(Settings.ConnectionSpeed.findFromValue(Settings.CONNECTIONSPEED.get()).toString())
-		}*/
 		addLabeled("Internet Bandwidth", connectionSpeed)
 		
 		addRow(CheckBox("Enable Cache").bind(Settings.ENABLECACHE))

--- a/src/main/xerus/monstercat/tabs/TabSettings.kt
+++ b/src/main/xerus/monstercat/tabs/TabSettings.kt
@@ -25,10 +25,7 @@ import org.controlsfx.validation.ValidationSupport
 import org.controlsfx.validation.Validator
 import xerus.ktutil.byteCountString
 import xerus.ktutil.javafx.*
-import xerus.ktutil.javafx.properties.ImmutableObservable
-import xerus.ktutil.javafx.properties.ImmutableObservableList
-import xerus.ktutil.javafx.properties.dependOn
-import xerus.ktutil.javafx.properties.listen
+import xerus.ktutil.javafx.properties.*
 import xerus.ktutil.javafx.ui.App
 import xerus.ktutil.javafx.ui.createAlert
 import xerus.monstercat.Settings
@@ -79,6 +76,20 @@ class TabSettings: VTab() {
 			@Suppress("UNCHECKED_CAST")
 			Settings.PLAYERSEEKBARHEIGHT.bind(valueProperty() as ObservableValue<out Double>)
 		})
+		
+		val connectionSpeed = ComboBox<String>(FXCollections.observableArrayList())
+		onFx {
+			Settings.ConnectionSpeed.values().reversedArray().forEach {
+				connectionSpeed.items.add(it.toString())
+			}
+			connectionSpeed.valueProperty().bindBidirectional(Settings.CONNECTIONSPEED, {
+				Settings.ConnectionSpeed.findFromString(it).maxConnections
+			}, {
+				Settings.ConnectionSpeed.findFromValue(it).toString()
+			})
+			connectionSpeed.select(Settings.ConnectionSpeed.findFromValue(Settings.CONNECTIONSPEED.get()).toString())
+		}
+		addLabeled("Internet Bandwidth", connectionSpeed)
 		
 		addRow(CheckBox("Enable Cache").bind(Settings.ENABLECACHE))
 		if(Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN))

--- a/src/main/xerus/monstercat/tabs/TabSettings.kt
+++ b/src/main/xerus/monstercat/tabs/TabSettings.kt
@@ -33,6 +33,7 @@ import xerus.monstercat.api.Cache
 import xerus.monstercat.cacheDir
 import xerus.monstercat.dataDir
 import xerus.monstercat.downloader.DownloaderSettings
+import xerus.monstercat.downloader.createComboBox
 import xerus.monstercat.logDir
 import xerus.monstercat.monsterUtilities
 import java.awt.Desktop
@@ -76,7 +77,9 @@ class TabSettings: VTab() {
 			@Suppress("UNCHECKED_CAST")
 			Settings.PLAYERSEEKBARHEIGHT.bind(valueProperty() as ObservableValue<out Double>)
 		})
-		
+
+		val connectionSpeed = createComboBox(Settings.CONNECTIONSPEED)
+		/*
 		val connectionSpeed = ComboBox<String>(FXCollections.observableArrayList())
 		onFx {
 			Settings.ConnectionSpeed.values().reversedArray().forEach {
@@ -88,7 +91,7 @@ class TabSettings: VTab() {
 				Settings.ConnectionSpeed.findFromValue(it).toString()
 			})
 			connectionSpeed.select(Settings.ConnectionSpeed.findFromValue(Settings.CONNECTIONSPEED.get()).toString())
-		}
+		}*/
 		addLabeled("Internet Bandwidth", connectionSpeed)
 		
 		addRow(CheckBox("Enable Cache").bind(Settings.ENABLECACHE))


### PR DESCRIPTION
This adds a new settings called "Connection speed" that changes the maximum number of simultaneous connections on APIConnection depending on the user's selected speed.

This is what it looks like : [Video](https://streamable.com/9vj9q)

Values are subject to be changed; needs testing. 30 is the good number on ADSL I've tested (3 different places with around 8Mb/s = 1MB/s)

- Dial-up : 100kb/s = 5 maxConnections

- ADSL / 3G : 10Mb/s = 30 maxConnections

- Cable / 4G : 100Mb/s = 150 maxConnections

- Fiber : 300+Mb/s = 300 maxConnections