### PR TITLE
Releases Browser

### DIFF
--- a/src/main/xerus/monstercat/MonsterUtilities.kt
+++ b/src/main/xerus/monstercat/MonsterUtilities.kt
@@ -33,11 +33,7 @@ import xerus.ktutil.to
 import xerus.monstercat.api.DiscordRPC
 import xerus.monstercat.api.Player
 import xerus.monstercat.downloader.TabDownloader
-import xerus.monstercat.tabs.BaseTab
-import xerus.monstercat.tabs.TabCatalog
-import xerus.monstercat.tabs.TabGenres
-import xerus.monstercat.tabs.TabSettings
-import xerus.monstercat.tabs.TabSound
+import xerus.monstercat.tabs.*
 import java.io.File
 import java.net.URL
 import java.net.UnknownHostException
@@ -101,6 +97,7 @@ class MonsterUtilities(checkForUpdate: Boolean): JFXMessageDisplay {
 		addTab(TabCatalog::class)
 		addTab(TabGenres::class)
 		addTab(TabDownloader::class)
+		addTab(TabReleases::class)
 		addTab(TabSound::class)
 		addTab(TabSettings::class)
 		if(currentVersion != Settings.LASTVERSION.get()) {

--- a/src/main/xerus/monstercat/api/Cache.kt
+++ b/src/main/xerus/monstercat/api/Cache.kt
@@ -18,7 +18,7 @@ import xerus.monstercat.downloader.CONNECTSID
 import xerus.monstercat.globalDispatcher
 import java.io.File
 
-private const val cacheVersion = 5
+private const val cacheVersion = 6
 
 object Cache: Refresher() {
 	private val logger = KotlinLogging.logger { }

--- a/src/main/xerus/monstercat/api/Covers.kt
+++ b/src/main/xerus/monstercat/api/Covers.kt
@@ -55,6 +55,16 @@ object Covers {
 		return coverFile.inputStream()
 	}
 	
+	fun getCachedCover(coverUrl: String, cachedSize: Int, imageSize: Int): Image? {
+		val coverFile = coverCacheFile(coverUrl, cachedSize)
+		return try {
+			val imageStream = coverFile.inputStream()
+			createImage(imageStream, imageSize)
+		} catch(e: Exception) {
+			null
+		}
+	}
+	
 	/** Fetches the given [coverUrl] with an [APIConnection] in the requested [size].
 	 * @param coverUrl the base url to fetch the cover
 	 * @param size the size of the cover to be fetched from the api, with all powers of 2 being available.

--- a/src/main/xerus/monstercat/api/response/Release.kt
+++ b/src/main/xerus/monstercat/api/response/Release.kt
@@ -14,6 +14,7 @@ data class Release(
 	@Key var renderedArtists: String = "",
 	@Key override var title: String = "",
 	@Key var coverUrl: String = "",
+	@Key("inEarlyAccess") var earlyAccess: Boolean = false,
 	@Key var downloadable: Boolean = false): MusicItem() {
 	
 	@Key var isCollection: Boolean = false

--- a/src/main/xerus/monstercat/tabs/BaseTab.kt
+++ b/src/main/xerus/monstercat/tabs/BaseTab.kt
@@ -2,6 +2,7 @@ package xerus.monstercat.tabs
 
 import javafx.scene.control.Control
 import javafx.scene.layout.Pane
+import javafx.scene.layout.StackPane
 import javafx.scene.layout.VBox
 import mu.KotlinLogging
 import org.controlsfx.validation.decoration.GraphicValidationDecoration
@@ -20,6 +21,14 @@ interface BaseTab {
 }
 
 abstract class VTab : VBox(), BaseTab {
+	protected val logger = KotlinLogging.logger(javaClass.name)
+	
+	init {
+		styleClass.add("vtab")
+	}
+}
+
+abstract class StackTab : StackPane(), BaseTab {
 	protected val logger = KotlinLogging.logger(javaClass.name)
 	
 	init {

--- a/src/main/xerus/monstercat/tabs/TabReleases.kt
+++ b/src/main/xerus/monstercat/tabs/TabReleases.kt
@@ -1,0 +1,104 @@
+package xerus.monstercat.tabs
+
+import javafx.collections.FXCollections
+import javafx.geometry.Insets
+import javafx.geometry.Pos
+import javafx.scene.Group
+import javafx.scene.control.Label
+import javafx.scene.control.Tooltip
+import javafx.scene.effect.GaussianBlur
+import javafx.scene.image.ImageView
+import javafx.scene.layout.Background
+import javafx.scene.layout.BackgroundFill
+import javafx.scene.layout.CornerRadii
+import javafx.scene.layout.HBox
+import javafx.scene.layout.StackPane
+import javafx.scene.paint.Color
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import org.controlsfx.control.GridCell
+import org.controlsfx.control.GridView
+import xerus.ktutil.javafx.add
+import xerus.ktutil.javafx.createButton
+import xerus.ktutil.javafx.onFx
+import xerus.ktutil.javafx.properties.SimpleObservable
+import xerus.ktutil.javafx.properties.listen
+import xerus.monstercat.api.Cache
+import xerus.monstercat.api.Covers
+import xerus.monstercat.api.response.Release
+import xerus.monstercat.monsterUtilities
+
+class TabReleases: StackTab() {
+	private var cols = SimpleObservable(3)
+	val cellSize: Double
+		get() = monsterUtilities.window.width / cols.value - 16.0 * (cols.value + 1)
+	
+	private val releases = FXCollections.observableArrayList<Release>()
+	
+	private val gridView = GridView<Release>().apply {
+		setCellFactory {
+			ReleasesGridCell(this@TabReleases).apply { setOnMouseClicked { showRelease(this.item) } }
+		}
+		horizontalCellSpacing = 16.0
+		verticalCellSpacing = 16.0
+		
+		fun setCellSize() {
+			cellWidth = cellSize
+			cellHeight = cellSize
+		}
+		setCellSize()
+		cols.listen { setCellSize() }
+		monsterUtilities.window.widthProperty().listen { setCellSize() }
+	}
+	
+	init {
+		gridView.items = releases
+		GlobalScope.launch {
+			val releases = Cache.getReleases()
+			onFx { this@TabReleases.releases.setAll(releases) }
+		}
+		val colEditor = Group(HBox(0.0,
+			createButton("-") { cols.value = (cols.value - 1).coerceAtLeast(2) },
+			createButton("+") { cols.value = (cols.value + 1).coerceAtMost(4) }))
+		add(gridView)
+		add(colEditor)
+		StackPane.setAlignment(colEditor, Pos.BOTTOM_LEFT)
+	}
+	
+	private fun showRelease(release: Release) {
+		val parent = HBox()
+		add(parent)
+	}
+	
+	class ReleasesGridCell(private val context: TabReleases): GridCell<Release>() {
+		override fun updateItem(item: Release?, empty: Boolean) {
+			super.updateItem(item, empty)
+			if(empty || item == null) {
+				graphic = null
+			} else {
+				val coverImage = Covers.getCachedCover(item.coverUrl, 1024, 256)
+					?: Covers.getThumbnailImage(item.coverUrl, 256)
+				val cover = ImageView(coverImage)
+				
+				cover.fitHeight = context.cellSize
+				cover.fitWidth = context.cellSize
+				context.cols.listen {
+					cover.fitHeight = context.cellSize
+					cover.fitWidth = context.cellSize
+				}
+				cover.effect = GaussianBlur(5.0)
+				graphic = StackPane(cover,
+					Label(item.toString()).apply {
+						background = Background(BackgroundFill(Color.BLACK.apply { setOpacity(0.6) }, CornerRadii(8.0), Insets.EMPTY))
+						padding = Insets(8.0)
+						translateY = -16.0
+					}
+				).apply {
+					alignment = Pos.BOTTOM_CENTER; tooltip = Tooltip(item.toString())
+					if(item.earlyAccess) style += "-fx-border-color: gold; -fx-border-width: 4px; -fx-border-radius: 8px"
+				}
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
Adds a release browser which shows album arts, releases names and artists, and can show one release's tracks in a beautiful manner.

## Current progress : 
### Browser :
![unknown](https://user-images.githubusercontent.com/19249728/62840749-b68c9800-bc9f-11e9-9d5d-5ce393369b8d.png)

- Shows cover arts
- Only shows high-res if already in the cache (still figuring out how to deal with it, how about creating a new cached size ? 512 or 256 should be plenty, 64 is a bit small and 1024 is way too much)
- Size of covers can be changed to show more or less releases at once
- Gold previews are shown with a gold border

### Draft for release view :
![DeepinScreenshot_select-area_20190811230648](https://user-images.githubusercontent.com/19249728/62840748-b68c9800-bc9f-11e9-8789-22e6e7faa89a.png)

