### PR TITLE
fix(downloader-tab): use invoke to return displayName and not enum name

### DIFF
--- a/src/main/xerus/monstercat/api/response/Release.kt
+++ b/src/main/xerus/monstercat/api/response/Release.kt
@@ -2,6 +2,7 @@ package xerus.monstercat.api.response
 
 import com.google.api.client.util.Key
 import mu.KotlinLogging
+import xerus.ktutil.helpers.Named
 import xerus.ktutil.to
 
 private val logger = KotlinLogging.logger { }
@@ -53,7 +54,7 @@ data class Release(
 	fun debugString(): String =
 		"Release(id='$id', releaseDate='$releaseDate', type='$type', renderedArtists='$renderedArtists', title='$title', coverUrl='$coverUrl', downloadable=$downloadable, isCollection=$isCollection)"
 	
-	enum class Type(val displayName: String, val isCollection: Boolean, val matcher: (Release.() -> Boolean)? = null): CharSequence by displayName {
+	enum class Type(override val displayName: String, val isCollection: Boolean, val matcher: (Release.() -> Boolean)? = null): Named {
 		MCOLLECTION("Monstercat Collection", true,
 			{ title.startsWith("Monstercat 0") || title.startsWith("Monstercat Uncaged") || title.startsWith("Monstercat Instinct") }),
 		BESTOF("Best of", true, { title.contains("Best of") || title.endsWith("Anniversary") }),
@@ -62,6 +63,9 @@ data class Release(
 		MIX("Mix", false, { type == "Mixes" }),
 		SINGLE("Single", false),
 		PODCAST("Podcast", false);
+		
+		operator fun invoke() = toString()
+		override fun toString() = displayName
 	}
 	
 }

--- a/src/main/xerus/monstercat/downloader/TabDownloader.kt
+++ b/src/main/xerus/monstercat/downloader/TabDownloader.kt
@@ -277,7 +277,7 @@ class TabDownloader: VTab() {
 		addRow(createButton("Smart select") {
 			songView.onReady {
 				GlobalScope.launch {
-					val albums = arrayOf(Type.ALBUM, Type.EP).map { songView.roots[it] }.filterNotNull()
+					val albums = arrayOf(Type.ALBUM(), Type.EP()).map { songView.roots[it] }.filterNotNull()
 					albums.forEach { it.isSelected = true }
 					@Suppress("UNCHECKED_CAST")
 					val selectedAlbums = albums.flatMap { it.children } as List<FilterableTreeItem<Release>>
@@ -293,7 +293,7 @@ class TabDownloader: VTab() {
 						false
 					}
 					logger.trace { "Filtered out Collections in Smart Select: $filtered" }
-					songView.getItemsInCategory(Type.SINGLE).filter {
+					songView.getItemsInCategory(Type.SINGLE()).filter {
 						val tracks = it.value.tracks
 						if(tracks.size == 1) { // an actual single, check it directly
 							val track = tracks.first()
@@ -305,7 +305,7 @@ class TabDownloader: VTab() {
 						} else { // has multiple tracks, check with collections
 							return@filter true
 						}
-					}.plus(songView.getItemsInCategory(Type.MCOLLECTION)).forEach {
+					}.plus(songView.getItemsInCategory(Type.MCOLLECTION())).forEach {
 						it.children.forEach {
 							@Suppress("UNCHECKED_CAST")
 							val tr = it as CheckBoxTreeItem<Track>


### PR DESCRIPTION
* Type.(type) now invokes like a function and returns the displayName. This is equivalent to doing .toString() or .displayName; not doing anything will still return the enum.

Fixes #81 Smart Select is Broken