### PR TITLE
fix(install4j): use latest jar as classpath

### DIFF
--- a/MonsterUtilities.install4j
+++ b/MonsterUtilities.install4j
@@ -19,7 +19,7 @@
       </executable>
       <java mainClass="xerus.monstercat.MainKt">
         <classPath>
-          <scanDirectory location="." failOnError="false" />
+          <archive location="MonsterUtilities-${compiler:sys.version}.jar" />
         </classPath>
       </java>
       <iconImageFiles>


### PR DESCRIPTION
Install4J doesn't overwrite the jar in the install directory; this commit doesn't change this but now uses the classpath of ONLY the latest version instead of every single jar.