### PR TITLE
fix(covers): catch covers API timeouts and hardcode cache file extensions

### DIFF
--- a/src/main/xerus/monstercat/api/Covers.kt
+++ b/src/main/xerus/monstercat/api/Covers.kt
@@ -16,7 +16,7 @@ object Covers {
 	private fun coverCacheFile(coverUrl: String, size: Int): File {
 		coverCacheDir.mkdirs()
 		val newFile = coverCacheDir.resolve(coverUrl.substringBeforeLast('/').substringAfterLast('/').replaceIllegalFileChars())
-		return coverCacheDir.resolve("${newFile.nameWithoutExtension}x$size.${newFile.extension}")
+		return coverCacheDir.resolve("${newFile.nameWithoutExtension}x$size.jpg") // FIXME : Do not hardcode extension
 	}
 		
 	/** Returns an Image of the cover in the requested size using caching.

--- a/src/main/xerus/monstercat/api/Covers.kt
+++ b/src/main/xerus/monstercat/api/Covers.kt
@@ -21,8 +21,11 @@ object Covers {
 		
 	/** Returns an Image of the cover in the requested size using caching.
 	 * @param size the size of the Image that is returned - the image file will always be 64x64 */
-	fun getThumbnailImage(coverUrl: String, size: Number = 64, invalidate: Boolean = false): Image =
+	fun getThumbnailImage(coverUrl: String, size: Number = 64, invalidate: Boolean = false) = try {
 		getCover(coverUrl, 64, invalidate).use { createImage(it, size) }
+	} catch (e: Exception) {
+		null
+	}
 	
 	/** Returns a larger Image of the cover in the requested size using caching.
 	 * @param size the size of the Image that is returned - the image file will always be 1024x1024 */

--- a/src/main/xerus/monstercat/downloader/SongView.kt
+++ b/src/main/xerus/monstercat/downloader/SongView.kt
@@ -219,10 +219,12 @@ class SongView(private val sorter: ObservableValue<ReleaseSorting>):
 			}
 			GlobalScope.launch(globalDispatcher) {
 				var image = Covers.getThumbnailImage(release.coverUrl, 16)
-				image.onError {
+				fun invalidateImage() {
 					image = Covers.getThumbnailImage(release.coverUrl, 16, true)
-					image.onError { logger.debug("Failed to load coverUrl ${release.coverUrl} for $release", it) }
+					image?.onError { logger.debug("Failed to load coverUrl ${release.coverUrl} for $release", it) }
 				}
+				if (image == null) invalidateImage()
+				else image!!.onError { invalidateImage() }
 				onFx {
 					treeItem.graphic = ImageView(image)
 					done++


### PR DESCRIPTION
Fixes #107 

Regarding the file extension hardcode : 
Other than grabbing the Content-Type header (which is cumbersome in the current scope), it is better for now to hardcode the file extension. Most file viewers today can recognize wrong extension and still read, for example, a png file disguised with a .jpg extension;