### PR TITLE
Fix Export Current Track to File issues on Windows

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
 	testImplementation("org.junit.jupiter", "junit-jupiter-api", junitVersion)
 	testRuntimeOnly("org.junit.jupiter", "junit-jupiter-engine", junitVersion)
 	testImplementation("io.kotlintest", "kotlintest-runner-junit5", "3.3.3")
+	implementation(kotlin("stdlib-jdk8"))
 }
 
 val jarFile
@@ -169,3 +170,11 @@ tasks {
 
 println("Java version: ${System.getProperty("java.version")}")
 println("Version: $version")
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.kotlinOptions {
+	jvmTarget = "1.8"
+}
+val compileTestKotlin: KotlinCompile by tasks
+compileTestKotlin.kotlinOptions {
+	jvmTarget = "1.8"
+}

--- a/src/main/xerus/monstercat/api/Player.kt
+++ b/src/main/xerus/monstercat/api/Player.kt
@@ -166,7 +166,10 @@ object Player: FadingHBox(true, targetHeight = 25) {
 				setOnReady {
 					label.text = "Now Playing: $track"
 					if(!Files.isDirectory(Settings.PLAYEREXPORTFILE())) {
-						Files.write(Settings.PLAYEREXPORTFILE(), arrayListOf("$track"), StandardOpenOption.CREATE)
+						Files.write(Settings.PLAYEREXPORTFILE(), arrayListOf("$track"),
+								StandardOpenOption.CREATE,
+								StandardOpenOption.WRITE,
+								StandardOpenOption.TRUNCATE_EXISTING)
 						logger.debug("""Wrote "$track" into export file (${Settings.PLAYEREXPORTFILE()})""")
 					}
 					val total = totalDuration.toMillis()

--- a/src/main/xerus/monstercat/api/Player.kt
+++ b/src/main/xerus/monstercat/api/Player.kt
@@ -114,7 +114,11 @@ object Player: FadingHBox(true, targetHeight = 25) {
 	fun reset() {
 		fadeOut()
 		if(!Files.isDirectory(Settings.PLAYEREXPORTFILE())) {
-			Files.write(Settings.PLAYEREXPORTFILE(), arrayListOf(""), StandardOpenOption.CREATE)
+			Files.newBufferedWriter(Settings.PLAYEREXPORTFILE(),
+					StandardOpenOption.TRUNCATE_EXISTING,
+					StandardOpenOption.WRITE,
+					StandardOpenOption.CREATE
+			).close()
 			logger.debug("Cleared export file (${Settings.PLAYEREXPORTFILE()}) from its contents")
 		}
 		GlobalScope.launch {
@@ -166,10 +170,12 @@ object Player: FadingHBox(true, targetHeight = 25) {
 				setOnReady {
 					label.text = "Now Playing: $track"
 					if(!Files.isDirectory(Settings.PLAYEREXPORTFILE())) {
-						Files.write(Settings.PLAYEREXPORTFILE(), arrayListOf("$track"),
-								StandardOpenOption.CREATE,
+						Files.newBufferedWriter(Settings.PLAYEREXPORTFILE(),
+								StandardOpenOption.TRUNCATE_EXISTING,
 								StandardOpenOption.WRITE,
-								StandardOpenOption.TRUNCATE_EXISTING)
+								StandardOpenOption.CREATE
+						).close()
+						Files.write(Settings.PLAYEREXPORTFILE(), track.toString().toByteArray())
 						logger.debug("""Wrote "$track" into export file (${Settings.PLAYEREXPORTFILE()})""")
 					}
 					val total = totalDuration.toMillis()


### PR DESCRIPTION
Really strange; Java on Windows doesn't clear the file before writing to it. You have to do it manually.