### PR TITLE
fix(catalog-tab): genre colors not appearing anymore

### DIFF
--- a/src/main/xerus/monstercat/tabs/TabCatalog.kt
+++ b/src/main/xerus/monstercat/tabs/TabCatalog.kt
@@ -36,7 +36,6 @@ private fun isColumnCentered(colName: String) = colName.containsAny("id", "cc", 
 class TabCatalog: TableTab() {
 	
 	private val searchView = SearchView<List<String>>()
-	private val searchables = searchView.options
 	
 	init {
 		table.setRowFactory {
@@ -51,7 +50,7 @@ class TabCatalog: TableTab() {
 			}
 		}
 		
-		searchables.setAll(MultiSearchable("Any", Type.TEXT) { it }, MultiSearchable("Genre (\"Label\")", Type.TEXT) { val c = cols.findAll("label"); it.filterIndexed { index, _ -> c.contains(index) } })
+		searchView.options.setAll(MultiSearchable("Any", Type.TEXT) { it }, MultiSearchable("Genre (\"Label\")", Type.TEXT) { val c = cols.findAll("label"); it.filterIndexed { index, _ -> c.contains(index) } })
 		setColumns(Settings.LASTCATALOGCOLUMNS.all)
 		
 		children.add(searchView)
@@ -168,7 +167,7 @@ class TabCatalog: TableTab() {
 					else -> SearchableColumn.simple(colName, Type.TEXT, colValue::invoke)
 				}
 				if(col is SearchableColumn<List<String>, *, *>)
-					searchables.add(col)
+					searchView.options.add(col)
 				if(isColumnCentered(colName))
 					col.style = "-fx-alignment: CENTER"
 				newColumns.add(col)

--- a/src/main/xerus/monstercat/tabs/TabCatalog.kt
+++ b/src/main/xerus/monstercat/tabs/TabCatalog.kt
@@ -29,9 +29,9 @@ import xerus.monstercat.api.response.Track
 import java.time.LocalTime
 import kotlin.math.absoluteValue
 
-val defaultColumns = arrayOf("Genre", "Artists", "Track", "Length")
-val availableColumns = arrayOf("ID", "Date", "B", "CC", "E", "Genre", "Subgenres", "Artists", "Track", "Comp", "Length", "BPM", "Key", "Fan Ratings")
-private fun isColumnCentered(colName: String) = colName.containsAny("id", "cc", "date", "bpm", "length", "key", "comp", "rating") || colName == "B" || colName == "E"
+val defaultColumns = arrayOf("Label", "Artists", "Track", "Length")
+val availableColumns = arrayOf("ID", "Date", "CC", "E", "Label", "Artists", "Track", "Comp", "Length", "BPM", "Key")
+private fun isColumnCentered(colName: String) = colName.containsAny("id", "cc", "date", "bpm", "length", "key", "comp") || colName == "E"
 
 class TabCatalog: TableTab() {
 	
@@ -41,7 +41,7 @@ class TabCatalog: TableTab() {
 	init {
 		table.setRowFactory {
 			TableRow<List<String>>().apply {
-				val genre = cols.find("Genre") ?: return@apply
+				val genre = cols.find("label") ?: return@apply
 				itemProperty().listen {
 					style = genreColor(it?.get(genre)?.let {
 						genreColors.find(it)
@@ -51,7 +51,7 @@ class TabCatalog: TableTab() {
 			}
 		}
 		
-		searchables.setAll(MultiSearchable("Any", Type.TEXT) { it }, MultiSearchable("Genre", Type.TEXT) { val c = cols.findAll("genre"); it.filterIndexed { index, _ -> c.contains(index) } })
+		searchables.setAll(MultiSearchable("Any", Type.TEXT) { it }, MultiSearchable("Genre (\"Label\")", Type.TEXT) { val c = cols.findAll("label"); it.filterIndexed { index, _ -> c.contains(index) } })
 		setColumns(Settings.LASTCATALOGCOLUMNS.all)
 		
 		children.add(searchView)
@@ -162,7 +162,7 @@ class TabCatalog: TableTab() {
 								it.toIntOrNull() ?: return@converter null
 							}?.let { LocalTime.of(it[0] / 60, it[0] % 60, it[1]) }
 						}
-					colName.contains("genre", true) ->
+					colName.contains("label", true) ->
 						TableColumn<List<String>, String>(colName)
 						{ colValue(it.value) ?: "" }
 					else -> SearchableColumn.simple(colName, Type.TEXT, colValue::invoke)

--- a/src/main/xerus/monstercat/tabs/TabCatalog.kt
+++ b/src/main/xerus/monstercat/tabs/TabCatalog.kt
@@ -20,6 +20,7 @@ import xerus.ktutil.javafx.ui.controls.MultiSearchable
 import xerus.ktutil.javafx.ui.controls.SearchView
 import xerus.ktutil.javafx.ui.controls.SearchableColumn
 import xerus.ktutil.javafx.ui.controls.Type
+import xerus.ktutil.nullIfEmpty
 import xerus.ktutil.toLocalDate
 import xerus.monstercat.Settings
 import xerus.monstercat.api.APIUtils
@@ -45,7 +46,7 @@ class TabCatalog: TableTab() {
 					style = genreColor(it?.get(genre)?.let {
 						genreColors.find(it)
 							?: genreColors.find(it.split(' ').map { it.first() }.joinToString(separator = ""))
-					}) ?: "-fx-background-color: transparent"
+					}.nullIfEmpty()) ?: "-fx-background-color: transparent"
 				}
 			}
 		}

--- a/src/main/xerus/monstercat/tabs/TabGenres.kt
+++ b/src/main/xerus/monstercat/tabs/TabGenres.kt
@@ -13,6 +13,12 @@ import xerus.ktutil.javafx.ui.FilterableTreeItem
 import xerus.monstercat.Settings.GENRECOLORINTENSITY
 
 val genreColors = RoughMap<String>()
+	.apply {
+		put("EP", "")
+		put("Compilation", "")
+		put("Album", "")
+		
+	}
 val genreColor = { item: String? ->
 	item?.let {
 		"-fx-background-color: %s%02x".format(it, GENRECOLORINTENSITY())
@@ -28,7 +34,7 @@ class TabGenres : FetchTab() {
 	init {
 		styleClass("tab-genres")
 		val searchField = TextField()
-		VBox.setMargin(searchField, Insets(0.0, 0.0, 6.0, 0.0)) // apparently can't set this in css
+		setMargin(searchField, Insets(0.0, 0.0, 6.0, 0.0)) // apparently can't set this in css
 		val root = FilterableTreeItem(StringRow())
 		root.bindPredicate(searchField.textProperty()) { row, text -> row.subList(0, 3).any { it.contains(text, true) } }
 		view.isShowRoot = false


### PR DESCRIPTION
MCatalog changed a few things in the sheet so genre colors were broken:
- Deleted Subgenre column (why...)
- Renamed Genre to Label (why???)
- Label is actually a very broad genre; no more subgenres like Neurofunk or Liquid DnB, only Drum and Bass now
- Removed brand column (Instinct / Uncaged)

I don't feel good about these changes but well it's their thing.

This fixes the genre colors not being applied because the column is now named "Label" instead. I also cleaned up the column list to get rid of the "column not found" warning.
Had to add exceptions to the genreColors map because your implementation of RoughMap does a search by checking if the input string is contained in any of the keys; this caused issues with "EP" since it's contained within "Drumstep".
Also cleaned up the code a tiny bit